### PR TITLE
Update details.mdx

### DIFF
--- a/docs/eln/details.mdx
+++ b/docs/eln/details.mdx
@@ -176,15 +176,16 @@ Changing a reaction is not possible by directly changing its scheme, rather it m
 
 The following figure shows a typical reaction **Scheme** with a reagent table. No solvents nor reaction temperature have been added yet. In general, you cannot edit grey fields in the reaction table.  
 ![Reagents_table](/img/reaction_details_modal.png)
-The used  samples are classified into **Starting materials**, **Reactants** and **Products**. The samples can be moved flexibly from one category to another with drag & drop symbol <Btn mixed={[faArrowsAlt]} color={"secondary"}/>. This grouping causes functional differences: The difference between the **Starting materials** and the **Reactants** lies in the way their corresponding samples are treated upon generation. This will become clear later on in this chapter when discussing adding samples to a reaction. Regarding the **Products**, their fields can only be modified to a limited extent to avoid misuse of the journal. Certain fields that can be obtained from the received quantity of the product are not open for input. The **Products** have a special treatment within the reaction, for example the analyses of the corresponding samples are stored and can be found in the **Analyses** tab. 
+
+The used samples are classified into **Starting materials**, **Reactants** and **Products**. The samples can be moved flexibly from one category to another with the drag & drop symbol <Btn mixed={[faArrowsAlt]} color={"secondary"}/>. This grouping causes functional differences: The difference between the **Starting materials** and the **Reactants** stands in the way their corresponding samples are treated upon generation. This will become clear later on in this chapter when adding samples to a reaction is discussed. Regarding the **Products**, their fields can only be modified to a limited extent to avoid misuse of the journal. Certain fields that can be obtained from the received quantity of the product are not open for input. The **Products** have a special treatment within the reaction, for example the analyses of the corresponding samples are stored and can be found in the **Analyses** tab. 
 
 A reaction can be populated with samples in two different ways: 
 1. Create new sample:
 ![Reaction create smaples](/img/reaction_create_samples.gif)
 
-The user can create new samples by pressing <Btn mixed={[faPlus]} color={"success"}/>  in the corresponding category **Starting materials**, **Reactants** or **Products**.  In this case, the **Starting materials** and the **Products** samples will be added to the samples list. The **Reactants** will be saved as samples, and they are initially displayed in the samples list, but when you save the reaction and reload the page, all **Reactants** are not displayed in the list anymore in order to avoid unnecessary accumulation of samples, which are very often used as reactants. The **Reactants**  samples are still accessible from within the reaction **Scheme** by pressing the reactant name. The **Reactants** can be selected from the drop-down menu **Reagents**, and they are also not added to the samples list.
+The user can create new samples by pressing <Btn mixed={[faPlus]} color={"success"}/>  in the corresponding categories **Starting materials**, **Reactants** or **Products**.  In this case, the **Starting materials** and the **Products** samples will be added to the samples list. The **Reactants** will be saved as samples, and they are initially displayed in the samples list, but when you save the reaction and reload the page, all **Reactants** are not displayed in the list anymore in order to avoid unnecessary accumulation of samples, which are very often used as reactants. The **Reactants** samples are still accessible from within the reaction **Scheme** by pressing the reactant name. The **Reactants** can be selected from the drop-down menu **Reagents**, and they are also not added to the samples list.
 
-The creation of samples does not directly result in a representation in the reaction scheme. Please save the reactin once after adding samples to it. After saving the reaction, all added samples appear also in the image of the reaction scheme.
+The creation of samples does not directly result in a representation in the reaction scheme. Please save the reaction once after adding samples to it. After saving the reaction, all added samples also appear in the image of the reaction scheme.
 
 :::caution Recommendation 
 If you want to see a reactant displayed in the samples list, change its status from Reactants to Starting materials. By definition, Reactants are not displayed in the samples list. 
@@ -193,11 +194,11 @@ If you want to see a reactant displayed in the samples list, change its status f
 2. Select samples from the samples list:
 ![Reaction drag samples](/img/reaction_drag_sample.gif)
 
-The user can select samples from the samples list if they are already there and drag and drop them using either one of the <Btn mixed={[faArrowsAlt]} color={"secondary"}/> symbols next to its molecular structure or next to the sample name and place the sample in the reaction. If you only want to adopt the molecular structure, then the <Btn mixed={[faArrowsAlt]} color={"secondary"}/> symbol next to the molecular structure in the sample list must be used for the drag & drop action. The internal process here corresponds to the **copy** action. If you want to carry out a reaction that uses existing samples, e.g. carry out a subsequent reaction and use a product from a previous reaction as starting material or use a chemical from a chemical container, then you should use the symbol <Btn mixed={[faArrowsAlt]} color={"secondary"}/> next to a sample name in the sample list and place the sample in the reaction using drag & drop. A **split** of the sample is generated internally in the system (recognizable by the generation of the sample number). This applies only to the **Starting materials** as dragging and dropping of samples to the **Reactants** section doesn‘t add anything to the samples list. Splitting is not possible for products, as they always have to be recreated, but **copy** is possible. 
+The user can select samples from the samples list if they are already there and drag and drop them by using either one of the <Btn mixed={[faArrowsAlt]} color={"secondary"}/> symbols next to its molecular structure or next to the sample name and place the sample in the reaction. If you only want to adopt the molecular structure, then the <Btn mixed={[faArrowsAlt]} color={"secondary"}/> symbol next to the molecular structure in the sample list must be used for the drag & drop action. The internal process here corresponds to the <b>copy</b> action. If you want to carry out a reaction that uses existing samples, e.g. a subsequent reaction including a product from a previous reaction as starting material or a chemical from a chemical container, then you should use the symbol <Btn mixed={[faArrowsAlt]} color={"secondary"}/> next to a sample name in the sample list and place the sample into the reaction using drag & drop. A **split** of the sample is generated internally by the system (recognizable by the generation of the sample number). This applies only to the **Starting materials** as dragging and dropping of samples to the **Reactants** section doesn‘t add anything to the samples list. Splitting is not possible for products, as they always have to be recreated, but **copy** is possible. 
 
 The user can choose either the **Starting materials** or the **Reactants** as a reference using the **Ref** switch. As a result, the selected reference is automatically assigned an equivalent **Equiv** of 1.000. Several **Starting materials** and **Reactants** can be added, but only one sample can be marked as reference material.        
 
-Mass can be represented in g, mg or μg, the volume in l, ml, μl, and the amount in mol or mmol. Entering one type of data leads to automatic calculation of the others. The volume is calculated only if the **molarity** of the sample is already set (please set it in the **properties** tab of the **sample**, accessible directly via click on the sample's name -> sample modal opens), and the equivalents are calculated unless the sample is a reference, then it gets a fixed equivalent of 1.000. By entering the mass, volume or amount of the reference, the remaining information for the further samples is calculated as soon as at least either the **amount** or the **Equiv** is given for them. 
+Mass can be represented in g, mg or μg, the volume in l, ml, μl, and the amount in mol or mmol. Entering one type of data leads to automatic calculation of the others. The volume is calculated only if the **molarity** of the sample is already set (please set it in the **properties** tab of the **sample**, accessible directly via click on the sample's name -> sample modal opens), and the equivalents are calculated unless the sample is a reference, then it gets a fixed equivalent of 1.000. By entering the mass, volume or amount of the reference, the remaining information for the further samples is calculated as soon as at least either the **amount** or the **Equiv** is given. 
 
 
 :::info  
@@ -208,14 +209,14 @@ Additional information on samples such as **Molarity**, **Purity** and others ne
 The calculation and display of the volume can only be correct if the molarity of the sample has been entered correctly and precisely in the sample. 
 ::: 
 
-An additional function is included within the reaction table, allowing to differentiate between reaction planning and implementation. You can find the function under the title **T/R**. <button className={"button button--xs button--success"} style={{padding:"2px", width:"27px", height:"27px"}}>t</button> means that you can enter/ calculate inputs according to the reaction planning. If you switch from <button className={"button button--xs button--primary"} style={{padding:"2px", width:"27px", height:"27px"}}>r</button>, you can enter the quantities actually received. This function was created so that in the event of a deviation (e.g. due to accuracy in the dosage) from the planned experiments, the values of both procedures are still available. 
+An additional function is included within the reaction table, allowing to differentiate between reaction planning and implementation. You can find the function under the title **T/R**. <button className={"button button--xs button--success"} style={{padding:"2px", width:"27px", height:"27px"}}>t</button> means that you can enter/calculate inputs according to the reaction plan. If you switch from <button className={"button button--xs button--primary"} style={{padding:"2px", width:"27px", height:"27px"}}>r</button>, you can enter the quantities actually received. This function was created so that in the event of a deviation (e.g. due to accuracy in the dosage) from the planned experiments, the values of both procedures are still available. 
 
 ![Reaction solvents](/img/reaction_solvents.png)
 The solvents can be introduced by expanding the grey area **Solvents**. The user can either pick a solvent from the drop-down **Default solvents**,  or  can use a sample as a solvent. Solvents added as a sample are stored as a reactant sample, i.e. the solvent can be created with <Btn mixed={[faPlus]} color={"success"}/>, but it is not displayed in the samples list.  If the sample is already in the samples list, it can be dragged and dropped with <Btn mixed={[faArrowsAlt]} color={"secondary"}/>, but no **copy** or **split** happens.  
 
-The solvent can be given a **Label** which is transferred to the reaction arrow when updated by the symbol <Btn mixed={[faSyncAlt]} color={"secondary"}/>. When specifying the solvents volumes **Vol** (in l, ml, or μl), the molarity of the reaction mixture **Conc** is automatically calculated based on the individual samples in the reaction table. You can add as many solvents as you want. If you are using more than one solvent, the volume ratio **Vol ratio** of the solvents to each other is displayed. You can also distinguish between solvent details in the planned and implemented reaction with <button className={"button button--xs button--success"} style={{padding:"2px", width:"27px", height:"27px"}}>t</button> (planned) and <button className={"button button--xs button--primary"} style={{padding:"2px", width:"27px", height:"27px"}}>r</button> (implemented). Samples and solvents in a reaction can be removed from the reaction using the button <Btn mixed={[faTrashAlt]} color={"danger"}/>. 
+The solvent can be given a **Label** which is transferred to the reaction arrow when updated by the symbol <Btn mixed={[faSyncAlt]} color={"secondary"}/>. When specifying the solvents volumes <b>Vol</b> (in l, ml, or μl), the molarity of the reaction mixture <b>Conc</b> is automatically calculated based on the individual samples in the reaction table. You can add as many solvents as you want. If you are using more than one solvent, the volume ratio <b>Vol ratio</b> of the solvents to each other is displayed. You can also distinguish between solvent details in the planned and implemented reaction with <button className={"button button--xs button--success"} style={{padding:"2px", width:"27px", height:"27px"}}>t</button> (planned) and <button className={"button button--xs button--primary"} style={{padding:"2px", width:"27px", height:"27px"}}>r</button> (implemented). Samples and solvents in a reaction can be removed from the reaction using the button <Btn mixed={[faTrashAlt]} color={"danger"}/>. 
 
-In the gray area **Conditions**, the user can **Select** special conditions required for the reaction from a drop-down menu. Those conditions include **UV**, **microwave**, **ultrasound**, **visible light**. The selected conditions are added to a field where the user can additionally add other conditions as free text.
+In the grey area **Conditions**, the user can **Select** special conditions required for the reaction from a drop-down menu. Those conditions include **UV**, **microwave**, **ultrasound**, **visible light**. The selected conditions are added to a field where the user can additionally add other conditions as free text.
 
 :::info
 Internal remark TO DO: showing the conditions in a gif would be great
@@ -233,11 +234,11 @@ Out of the  **Conditions** area, the user can give their reaction a **Name** and
 | <FontAwesomeIcon icon={faTimesCircle} size="lg"/> | not successful | 
 
 
-The temperature of a reaction is inserted via the **Temperature** field. If a **Temperature** has been defined, it is also displayed on the reaction arrow. When entering the temperature, you can choose between the Kelvin **K**, Celsius **°C** and Fahrenheit **°F** scale. Enter the temperature in the given scale and switch to the desired unit. You can also enter a complex temperature profile by selecting the graph symbol for the temperature field <Btn mixed={[faChartArea]} color={"secondary"}/>. A window opens that allows you to enter temperature changes with time, and it displays those changes in a chart. Use + to add a temperature change and – to remove it.  
+The temperature of a reaction is inserted via the **Temperature** field. If a **Temperature** has been defined, it is also displayed on the reaction arrow. When entering the temperature, you can choose between the Kelvin **K**, Celsius **°C** and Fahrenheit **°F** scale. Enter the temperature in the given scale and switch to the desired unit. You can also enter a complex temperature profile by selecting the graph symbol for the temperature field <Btn mixed={[faChartArea]} color={"secondary"}/>. A window opens that allows you to enter temperature changes with time, and it displays those changes in a chart. Use "+" to add a temperature change and "–" to remove it.  
 
-The user can specify the **Duration** of the reaction by adding its **Start** time and **Stop** time with the following format: DD/MM/YYYY hh:mm:ss or DD.MM.YYYY hh:mm:ss, then the **Duration** is automatically calculated. The user can also input current time with the <Btn mixed={[faClock]} color={"secondary"}/> button. The calculated **Duration** can be copied with <Btn mixed={[faPaste]} color={"secondary"}/>, or rounded to the next field either in **Week(s)**, **Day(s)**, **Hour(s)**, **Minute(s)**, or **Second(s)**. 
+The user can specify the **Duration** of the reaction by adding its **Start** time and **Stop** time with the following format: DD/MM/YYYY hh:mm:ss or DD.MM.YYYY hh:mm:ss, then the **Duration** is automatically calculated. The user can also input the current time with the <Btn mixed={[faClock]} color={"secondary"}/> button. The calculated <b>Duration</b> can be copied with <Btn mixed={[faPaste]} color={"secondary"}/>, or rounded to the next field either in **Week(s)**, **Day(s)**, **Hour(s)**, **Minute(s)**, or **Second(s)**. 
 
-The **Type** of reactions can be chosen from the **Name Reaction Ontology** drop-down. The selection of an ontology is required if the data should be added to the repository chemotion, it is also recommended for all other reactions. Also the a **Role** can be assigned to a reaction. Available options are **General Procedure**, **Parts of GB**, and **Single**. The assignment of a role gives first of all an information that is reflected in the reaction list and allows an easy identification of e.g. general procedures in the list. the role assignment is also important for the use of the reporting function. The reporting function separates general procedures from reactions that were done according to a general procedure and reactions that are described as single (independent) reactions without assignment to a general procedure. For reactions that are **Parts of GP** (Parts of General Procedures), the description is not added to the reporting as it is assumed that the description of the reaction is the same for reactions done according to general procedures. In these cases, it is important to add the purification details to the field "additional information for publication and purification details" as this information is given in the reporting anyhow.
+The **Type** of reactions can be chosen from the **Name Reaction Ontology** drop-down. The selection of an ontology is required if the data should be added to the repository <b>Chemotion</b>, it is also recommended for all other reactions. Also, the **Role** can be assigned to a reaction. Available options are **General Procedure**, **Parts of GP**, and **Single**. The assignment of a role gives first of all an information that is reflected in the reaction list and allows an easy identification of e.g. general procedures in the list. The role assignment is also important for the use of the reporting function. The reporting function separates general procedures from reactions that were done according to a general procedure and reactions that are described as single (independent) reactions without assignment to a general procedure. For reactions that are **Parts of GP** (Parts of General Procedures), the description is not added to the report as it is assumed that the description of the reaction is the same for reactions done according to general procedures. In these cases, it is important to add the purification details to the field "additional information for publication and purification details" as this information is given in the report anyhow.
 
 The **Description** field is intended for recording your reaction implementation.   
 
@@ -250,21 +251,21 @@ Finally, the user can <Btn mixed={["Save"]} color={"warning"}/> the reaction, <B
 
 The **Properties** tab allows you to enter further details on the reaction. In addition to the fields **Name**, **Status**, **Temperature**, and **Type (Chemical Methods Ontology)** that are already mirrored in **Scheme** tab, new fields are introduced such as **Dangerous Products** where you can list whether dangerous substances occur in your reaction and classify their hazard from a drop-down menu.  
 
-In order to be able to reproduce the control of a reaction via thin-layer chromatography, two fields have been developed which are supposed to store the solvents used and their ratio on one hand, and the **Rf value** of the target product of the reaction on the other hand. Please enter the solvent information in the **Solvents (parts)** field and enter a space then the ratio of solvents to each other  according to this example: ethyl acetate/hexane 2:1. You can also provide further details about your thin layer chromatography in the **Description** field, e.g. the shape of the spots, or special features of the implementation. Here you can also state how the compounds were identified, i.e. which staining solutions were used or which wavelength was selected for the UV detection. 
+In order to be able to reproduce the control of a reaction via thin-layer chromatography, two fields have been developed which are supposed to store the solvents used and their ratio on the one hand, and the **Rf value** of the target product of the reaction on the other hand. Please enter the solvent information in the **Solvents (parts)** field followed by a space and the ratio of solvents to each other according to this example: ethyl acetate/hexane 2:1. You can also provide further details about your thin-layer chromatography in the **Description** field, e.g. the shape of the spots or special features of the implementation. Here you can also state how the compounds were identified, i.e. which staining solutions were used or which wavelength was selected for the UV detection. 
 
 ### References tab
 
-The ** References ** tab of a reaction is identical to the **Literature** tab of a sample. It allows you to manage your literature and link it to your reaction. You can specify as many references as you find needed. It is possible to specify the reference either by its DOI or ISBN, or by giving it a title and a URL. In both cases, you can add whether this reference is citing you or cited by you. When all details of a reference are entered, press <Btn mixed={[faPlus]} color={"success"}/>. Once a reference is created, it cannot be edited, it can only be deleted, so if you need to edit a reference, delete it and create a new one.  
+The ** References ** tab of a reaction is identical to the **Literature** tab of a sample. It allows you to manage your literature and link it to your reaction. You can specify as many references as you find needed. It is possible to specify the reference either by its DOI or ISBN, or by giving it a title and a URL. In both cases, you can add whether this reference is citing you or cited by you. When all details of a reference are entered, press <Btn mixed={[faPlus]} color={"success"}/>. Once a reference is created, it cannot be edited, it can only be deleted instead, so if you need to edit a reference, delete it and create a new one.  
 
-The created references are added to a list and they are shown in blue to indicate their functionality in linking to some resources by clicking on them. Each reference can by copied using <Btn mixed={[faPaste]} color={"secondary"}/>, which will copy the information provided in the list. Additional details about the reference, as by whom it was created and whether it is referring to or cited by you,  can be shown by pressing the button <Btn mixed={[faAngleRight]} color={"secondary"}/>, which also shows the delete button <Btn mixed={[faTrashAlt]} color={"danger"}/>. Don’t forget to save your changes with <Btn mixed={["Save"]} color={"warning"}/>. 
+The created references are added to a list and they are shown in blue to indicate their functionality in linking to some resources by clicking on them. Each reference can by copied by using <Btn mixed={[faPaste]} color={"secondary"}/>, which will copy the information provided in the list. Additional details about the reference, as by whom it was created and whether it is referring to or cited by you, can be shown by pressing the button <Btn mixed={[faAngleRight]} color={"secondary"}/>, which also shows the delete button <Btn mixed={[faTrashAlt]} color={"danger"}/>. Don’t forget to save your changes with <Btn mixed={["Save"]} color={"warning"}/>. 
 
 ### Analyses tab
 
-The analyses tab of the reaction view differs from the analysis tab of the sample view in essential ways. While a samples can always have analyses, reaction **Analyses** can only contain **Products** samples that are supported by analyses. The **Analyses** tab of the reactions therefore only shows analyses by means of a link. To edit the data, the link (name of the product sample) to the analysis of the sample must be followed. 
+The analyses tab of the reaction view differs from the analysis tab of the sample view in essential ways. While samples can always have analyses, reaction **Analyses** can only contain **Products** samples that are supported by analyses. The **Analyses** tab of the reactions therefore only shows analyses by means of a link. To edit the data, the link (name of the product sample) to the analysis of the sample must be followed. 
 
 ### Green chemistry tab
 
-This tab contains fields for green chemistry metrics to quantify the environmental performance of your reaction. Those fields are **Simple E factor (sEF)**, **Complete E factor (cEF)**, **Custom E factor**, **Atom economy (AE)**, **Custom Atom economy**. Those metrics are calculated automatically based on the masses of the samples in your reaction, and the waste produced through it. All the reaction samples are shown again in the **Green Chemistry** tab, with directly unmodifiable details about their **Mass**, **Volume**, **Moles**, and equivalents **Eguiv**. To modify those fields you need to go back to the corresponding sample and update the numbers, while you can modify the coefficients field **Coeff** directly from the **Green Chemistry** tab. The user can specify whether the **Starting Materials** and the **Reactants** are **Recyclable**, and they can specify whether their **Products** are **Waste** with a checkbox. If you are facing any problems with ticking the checkbox, make sure that you are using Chrome, and try to save the reaction and reload the page. 
+This tab contains fields for green chemistry metrics to quantify the environmental performance of your reaction. Those fields are **Simple E factor (sEF)**, **Complete E factor (cEF)**, **Custom E factor**, **Atom economy (AE)**, **Custom Atom economy**. Those metrics are calculated automatically based on the masses of the samples in your reaction, and the waste produced through it. All the reaction samples are shown again in the **Green Chemistry** tab, with directly unmodifiable details about their **Mass**, **Volume**, **Moles**, and equivalents **Equiv**. To modify those fields you need to go back to the corresponding sample and update the numbers, while you can modify the coefficients field **Coeff** directly from the **Green Chemistry** tab. The user can specify whether the **Starting Materials** and the **Reactants** are **Recyclable**, and they can specify whether their **Products** are **Waste** with a checkbox. If you are facing any problems with ticking the checkbox, make sure that you are using Chrome, and try to save the reaction and reload the page. 
 
 ### Scifinder tab
 
@@ -281,12 +282,12 @@ The **Designer** tab graphically displays the wells and shows how they are fille
 ### List tab
 ![Wellplate list](/img/wellplate_list.png)
 
-the **List** tab can be used to organize the samples collected in the wellplate. All inserted samples appear automatically in list form according to their assignment in the **Designer** (**Position**). The table of the list also contains the information about molecular structure (**Molecule**), **Name**, **External label**, **Sum Formula**, **Readout** and **Imported Readout**. The **Readout** field values are displayed again in the **Designer** tab when selecting individual wells.  
+The **List** tab can be used to organize the samples collected in the wellplate. All inserted samples appear automatically in list form according to their assignment in the **Designer** (**Position**). The table of the list also contains the information about molecular structure (**Molecule**), **Name**, **External label**, **Sum Formula**, **Readout** and **Imported Readout**. The **Readout** field values are displayed again in the **Designer** tab when selecting individual wells.  
 
 ### Properties tab
 ![Wellplate properties](/img/wellplate_properties.png)
 
-**Properties** tab  allows you to enter additional information about a wellplate, such as a **Name**, its **Size**, which is fixed as 96 at the moment, and a **Description**. 
+The **Properties** tab allows you to enter additional information about a wellplate, such as a **Name**, its **Size** (which is fixed as 96 at the moment) and a **Description**. 
 
 ### Analyses tab
 
@@ -294,7 +295,7 @@ You can create as many analyses for a sample as you need with the button <Btn mi
 
 The uploaded records can be supplemented with information in an input modal available for each data file. The input modal opens either when you create a new data record, or when you click on the link generated by the name of existing data records.  
 
- The analysis methods, from which you can choose, are given by the drop-down menu **Type (Chemical Methods Ontology)**. You shouldn't forget one important property of the  Chemotion ELN: the uploaded data files and entered information are not saved until you confirm that with <Btn mixed={["Save"]} color={"warning"}/> or <Btn mixed={[faSave]} color={"warning"}/>. This point if overlooked can lead to the loss of the data you have set. 
+ The analysis methods, from which you can choose, are given by the drop-down menu **Type (Chemical Methods Ontology)**. You shouldn't forget one important property of the  Chemotion ELN: the uploaded data files and entered information are not saved until you confirm that with <Btn mixed={["Save"]} color={"warning"}/> or <Btn mixed={[faSave]} color={"warning"}/>. This point, if overlooked, can lead to the loss of the data you have set. 
 
 You can delete your datasets from within your analysis by clicking <Btn mixed={[faTrashAlt]} color={"danger"}/>, or install it as a zip file with <Btn mixed={[faDownload]} color={"info"}/> 
 
@@ -302,15 +303,15 @@ You can delete your datasets from within your analysis by clicking <Btn mixed={[
 
 In the future, it should also be possible to use the Chemotion ELN for the documentation of biological experiments. The structure of this biological work should be possible through the element **Screen**. All descriptions and procedures of biological work for a planned experiment are recorded on a screen while the wellplates define the localization of the substances and materials used. Wellplates can therefore also be assigned to the individual screens in order to make their affiliation clear. 
 
-So far, only a rudimentary structure for entering the screens has been programmed. The further development is an important task within the project in the coming months. The most important data of a biological study can be saved by entering free text in the **Name**, **Collaborator**, **Requirements**, **Conditions**, **Result** and **Description** fields. The allocation of the wellplates required for the examination can be done via drag & drop directly under the heading **Wellplates**. The selected wellplates are added and are directly available through a link. 
+So far, only a rudimentary structure for entering the screens has been programmed. The further development is an important task within the project in the coming months. The most important data of a biological study can be saved by entering free text in the **Name**, **Collaborator**, **Requirements**, **Conditions**, **Result** and **Description** fields. The allocation of the wellplates required for the examination can be done via drag & drop directly under the heading **Wellplates**. The selected wellplates are added and directly available through a link. 
 
 ## Detail modal for research plan
 ![Reseach plan](/img/research_plan.png)
 
-A research plan is a generic element that can be used in a flexible manner to describe a particular process. The research plan contains a **Name**, and there are plenty of fields that can be added in the form of text (**Add Text Editor**), tables (**Add Table Editor**), images (either a molecular structure with **Add Ketcher Editor**, or a regular image with **Add Image** where you can control its **Zoom** ). You can add other elements such as samples (**Add Sample**) and reactions (**Add Reaction**) with drag and drop. 
-The order of the segments added to the research plan ccan be changed by drag and drop. 
+A research plan is a generic element that can be used in a flexible manner to describe a particular process. The research plan contains a **Name**, and there are plenty of fields that can be added in the form of text (**Add Text Editor**), tables (**Add Table Editor**), images (either a molecular structure with **Add Ketcher Editor**, or a regular image with **Add Image** where you can control its **Zoom**). You can add other elements such as samples (**Add Sample**) and reactions (**Add Reaction**) with drag and drop. 
+The order of the segments added to the research plan can be changed by drag and drop. 
 
-The reserach plan has an edit and a view mode. The view mode offers options to export the information to different file formats (.docx, .odt, HTML, Markdown, LaTeX). 
+The research plan has an edit and a view mode. The view mode offers options to export the information to different file formats (.docx, .odt, HTML, Markdown, LaTeX). 
 
 :::info
 Internal remark TO DO: gif showing export functions
@@ -319,50 +320,50 @@ Internal remark TO DO: gif showing export functions
 
 ### Research plan table functions
 
-#### Add/remove column and row
+#### Add/remove columns and rows
 
-You can add or remove column and row by right-click on the table body. Then you can choose the action you want to make.
+You can add or remove columns and rows by right-clicking on the table body. Then you can choose the action you want to make.
 
 ![Reseach plan](/img/manage_column_row.gif)
 
-#### Reorder/sort column and row
+#### Reorder/sort columns and rows
 
 Reorder:
 
-- You can reorder row by click on the icon in each cell and drag-drop.(You cannot reorder row when in sorted mode)
+- You can reorder rows by clicking on the icon in each cell and drag-drop.(You cannot reorder rows when in sorted mode)
 
-- You can reorder column by click on the column header and drag-drop.
+- You can reorder columns by clicking on the respective column header and drag-drop.
 
 Sort:
 
-- You can sort by column by click on the column header.
+- You can sort by column by clicking on the column header.
 
 ![Reseach plan](/img/reorder_column_row.gif)
 
-#### Rename column
+#### Rename columns
 
-You can rename column by right-click on the column cell and choose 'Rename column', the rename popup will apear. Then input the new name and click 'Rename column' button.
+You can rename columns by right-clicking on the column cell and choose 'Rename column', the rename popup will apear. Then input the new name and click 'Rename column' button.
 
 ![Reseach plan](/img/rename_column.gif)
 
-#### Manage table schemas
+#### Manage table schemes
 
-- When you want to store a table schema:
+- When you want to store a table scheme:
 
-    - Click on 'Table schemas' button.
+    - Click on 'Table schemes' button.
 
-    - The 'Table schemas' modal will appear. 
+    - The 'Table schemes' modal will appear. 
 
-    - Then input the schema name and click 'Save' button.
+    - Then input the scheme name and click 'Save' button.
 
 ![Reseach plan](/img/Table_Schema_Save.gif)
 
-- When you want to apply a table schema:
+- When you want to apply a table scheme:
 
-    - Click on 'Table schemas' button.
+    - Click on 'Table schemes' button.
 
-    - The 'Table schemas' modal will appear. 
+    - The 'Table schemes' modal will appear. 
     
-    - Click 'Use' button to apply the table schema name.
+    - Click 'Use' button to apply the table scheme name.
 
 ![Reseach plan](/img/Table_Schema_Apply.gif)


### PR DESCRIPTION
179: Leerzeile, weil das "The" noch in der vorherigen Zeile zu sehen ist; the drag&drop symbol; stands statt lies; is discussed statt discussing
186: categories; Leerzeichen weg
188: reaction; also vor appear
197: by using; aus welchen gründen auch immer wird mir copy nicht als fett angezeigt...; Satz bei e.g. verändert; into statt in; by statt in
201: nur is given
212: Leerzeichen weg; reaction plan oder planned reaction aber nicht planning
217: nach Label sehe ich nichts mehr in fett...
219 grey (einheitlich)
222: ??
237: in "
239: the current time; Duration wieder nicht fett
241: GP statt GB; Chemotion groß und ggf fett; Komma; a bei role weg; Satzanfang groß report satt reporting
254: on the one hand; Teil mit solvents leserlicher gemacht; TLC mit Bindestrich, Leerzeichen zu viel, Komma nach spots weg
258: instead
260: by; Leerzeichen
264: samples weg
268: Equiv
285: The am Satzanfang groß
290: The am Anfang; Leerzeichen (LZ) zu viel; Klammern statt Kommata
298: if overlooked in Kommata
306: are weg
311: LZ vor ) weg
312: can
314: research
317:???
323+329: columns and rows
325: columns and rows; clicking
333: rows; clicking
335: columns; clicking; respective
339: clicking
343: columns
345: columns; clicking
349: schemes; 349-369: eigentlich heißt das scheme...