### PR TITLE
Amendments to Docker documentation

### DIFF
--- a/docs/eln/installation/docker_installation.mdx
+++ b/docs/eln/installation/docker_installation.mdx
@@ -9,6 +9,12 @@ slug: docker_installation
 Documentation and processes are being reworked and improved at the moment. It may happen that you miss information. If you face problems, please let us know, we are there to support you. You may also [contact](specific_contact) us directly if you plan to install Chemotion. 
 :::
 
+## Prerequisites
+
+To setup the Chemotion ELN using Docker, Docker Engine and Docker Compose have to be installed on the host machine. Please refer to the [Docker distributions documentation](https://docs.docker.com/desktop/install/linux-install/) on how this can be achieved. For Ubuntu-based machines, this can be found [here](https://docs.docker.com/engine/install/ubuntu/).
+
+The Docker Daemon may be configured to run as a non-root user (Rootless mode). Please see the distribution-specific [setup instructions](https://docs.docker.com/engine/security/rootless/) for details.
+
 ## Version 1.4.1 {#version-141}
 
 The latest version of the Chemotion images is `1.4.1-2` as listed on [DockerHub](https://hub.docker.com/repository/docker/ptrxyz/chemotion).
@@ -328,7 +334,7 @@ On the inside, we managed to reduce the size of our images by more than 50% by b
 
 
 ## Preparation
-To setup the Chemotion ELN using Docker, Docker and Docker Compose have to be installed on the host machine. Please refer to your distributions documentation on how this can be achieved. For Ubuntu-based machines, this can be found [here](https://docs.docker.com/engine/install/ubuntu/).
+To setup the Chemotion ELN using Docker, Docker Engine and Docker Compose have to be installed on the host machine. Please refer to the [Docker distributions documentation](https://docs.docker.com/desktop/install/linux-install/) on how this can be achieved. For Ubuntu-based machines, this can be found [here](https://docs.docker.com/engine/install/ubuntu/).
 
 In addition you need that latest version of our Docker Compose service description as well as some scripts depending on your scenario. The file can be found here:
 

--- a/docs/eln/installation/docker_installation.mdx
+++ b/docs/eln/installation/docker_installation.mdx
@@ -90,12 +90,12 @@ Before you upgrade your Chemotion installation, please make sure you have a back
 
 To upgrade a default installation, the following steps need to be taken:
 
-- shutdown your Chemotion instance (`docker-compose down --remove-orphans`)
+- shutdown your Chemotion instance (`docker compose down --remove-orphans`)
 - replace your docker-compose.yml file with the one for version 1.4.1 (see [this](#version-141)).
 - delete the Chemotion app volume (by default this is named "chemotion_app", `docker volume rm chemotion_app`).
 - configure the PUBLIC_URL variable as described [here](#publicurl-141)
 - configure the converter service as described in the documentation or in the [section above](#fresh-141).
-- restart the system using `docker-compose up`.
+- restart the system using `docker compose up`.
 
 ## Version 1.3.0p220705
 
@@ -117,17 +117,17 @@ wget https://raw.githubusercontent.com/ptrxyz/chemotion/latest-release/docker-co
 
 - download all images and create the containers, data volumes and networks by running this command in the same folder you downloaded the compose file to:
 ```
-docker-compose create
+docker compose create
 ```
-Note: depending on your Compose version you might get a deprecation warning. The warning can be ignored for now, in the future, `docker-compose up --no-start` will be a drop-in replacement for this command.
+Note: depending on your Compose version you might get a deprecation warning. The warning can be ignored for now, in the future, `docker compose up --no-start` will be a drop-in replacement for this command.
 
 - Start the ELN containers with
 ```
-docker-compose up
+docker compose up
 ```
 or 
 ```
-docker-compose up -d
+docker compose up -d
 ```
 (the 1st command outputs to stdout, the 2nd starts the ELN as a background service login to the docker's log daemon)
 - after a short startup/migration period, the ELN will available on port `<your host IP>:4000`
@@ -141,10 +141,10 @@ Please do always create a backup of your data before upgrading. No backup - no p
 
 To upgrade to 1.1.3 from 1.1.2, simply follow these steps:
 
-- Stop all running containers: `docker-compose down --remove-orphans`
+- Stop all running containers: `docker compose down --remove-orphans`
 - Delete the APP volume: `docker volume rm chemotion_app`
 - Get the latest compose file: `wget -O docker-compose.yml https://raw.githubusercontent.com/ptrxyz/chemotion/latest-release/docker-compose.yml`
-- Restart the containers: `docker-compose up`
+- Restart the containers: `docker compose up`
 
 ## Version 1.1.2p220401
 
@@ -169,17 +169,17 @@ wget https://raw.githubusercontent.com/ptrxyz/chemotion/release-112/release/1.1.
 
 - download all images and create the containers, data volumes and networks by running this command in the same folder you downloaded the compose file to:
 ```
-docker-compose create
+docker compose create
 ```
-Note: depending on your Compose version you might get a deprecation warning. The warning can be ignored for now, in the future, `docker-compose up --no-start` will be a drop-in replacement for this command.
+Note: depending on your Compose version you might get a deprecation warning. The warning can be ignored for now, in the future, `docker compose up --no-start` will be a drop-in replacement for this command.
 
 - Start the ELN containers with
 ```
-docker-compose up
+docker compose up
 ```
 or 
 ```
-docker-compose up -d
+docker compose up -d
 ```
 (the 1st command outputs to stdout, the 2nd starts the ELN as a background service login to the docker's log daemon)
 - after a short startup/migration period, the ELN will available on port `<your host IP>:4000`
@@ -197,7 +197,7 @@ We recommend the following steps:
 
 - Bring down your current instance, backup everything:
 ```
-docker-compose down --remove-orphans
+docker compose down --remove-orphans
 sudo tar cvzf /tmp/pre-upgrade.tar.gz ./db-data ./shared ./docker-compose.yml
 ```
 In case anything goes wrong, you can always fall back to this backup by simply extracting the archive.
@@ -215,7 +215,7 @@ wget https://raw.githubusercontent.com/ptrxyz/chemotion/latest-release/docker-co
 
 - download all images and create the containers, data volumes and networks by running this command in the same folder you downloaded the compose file to:
 ```
-docker-compose create
+docker compose create
 ```
 
 - start a disposable sidecar container with an interactive shell attaching your old data and old db stores in addition to the storages defined in `docker-compose.yml`:
@@ -238,7 +238,7 @@ Note: the point here is that you copy everything from your old `uploads` and `pu
 - Your data is now stored on the data volumes. Type `exit` to quit the interactive shell.
 - start your new instances:
 ```
-docker-compose up
+docker compose up
 ```
 - after a short startup/migration period, the ELN will available on port `<your host IP>:4000`
 - Proceed with the sections [Configuring](#config-112p220401) and [Setting the Base URL](#baseurl-112p220401)
@@ -277,42 +277,42 @@ Note: Settings protocol to `https` requires you to configure TLS on your machine
 
 The new version comes with some quality-of-life changes:
 
-- to check the logs of a service, use either `docker-compose logs` or check the `./shared/logs` folder.
+- to check the logs of a service, use either `docker compose logs` or check the `./shared/logs` folder.
 - to create a backup of your data, you can use the embedded Chemotion CLI tools:
 ```
-docker-compose exec eln chemotion backup
+docker compose exec eln chemotion backup
 ```
 This will create a backup in ./shared/backup/
 - to restore a backup, clean out your Compose-directory, keep only the backup folder and it's files in place.
 ```
-docker-compose down --remove-orphans       # stop all services
-docker-compose run eln chemotion restore   # restore the latest backup
+docker compose down --remove-orphans       # stop all services
+docker compose run eln chemotion restore   # restore the latest backup
 ```
 - Resetting the Administrator account's password:
 ```
-docker-compose exec eln chemotion resetAdminPW
+docker compose exec eln chemotion resetAdminPW
 ```
 - Getting a Rails console:
 ```
-docker-compose exec eln chemotion railsc
+docker compose exec eln chemotion railsc
 ```
 - Getting a shell with loaded Chemotion environment variables:
 ```
-docker-compose exec eln chemotion shell
+docker compose exec eln chemotion shell
 ```
 - Drop to Postgres console in the Chemotion database:
 ```
-docker-compose exec eln chemotion psql
+docker compose exec eln chemotion psql
 ```
 - Display basic version information:
 ```
-docker-compose exec eln chemotion info
+docker compose exec eln chemotion info
 ```
 
 #### Notes on Backups:
 
 The backup script is meant to simplify your life a bit when it comes to backups. However it doesn't do anything magical and if it suits your needs better, you can also do manual backups. To create on, you need to dump your database, i.e. with `pg_dump` or by copying the `chemotion_db` volume when the database is not running.
-In addition, you need to safe all your data, that is two folders: `/uploads` and the `/public/images` (the latter being more a convenience thing preventing you from having to recreate a lots of thumbnails after restoration). The data is stored on the `chemotion_data` volume, so you can simply mount it somewhere and use rsync/tar/cp to copy the data. If you already have a container mounting this volume, such as (such as the `eln` or `worker` services), you can also simply use `docker-compose cp` or `docker cp` to copy the data to the host machine and do anything you like with it.
+In addition, you need to safe all your data, that is two folders: `/uploads` and the `/public/images` (the latter being more a convenience thing preventing you from having to recreate a lots of thumbnails after restoration). The data is stored on the `chemotion_data` volume, so you can simply mount it somewhere and use rsync/tar/cp to copy the data. If you already have a container mounting this volume, such as (such as the `eln` or `worker` services), you can also simply use `docker compose cp` or `docker cp` to copy the data to the host machine and do anything you like with it.
 
 To restore a backup, invert the process: While backups can be done with running services, for restoration, you need to stop your services, then playback the SQL-dump (pg_restore/psql/copy the volume or data files back) and then playback the data using cp/tar/rsync/etc.
 
@@ -320,7 +320,7 @@ To restore a backup, invert the process: While backups can be done with running 
 
 With release `1.0.3D0.1`, beside upgrading the ELN version to 1.0.3, we made great improvements to the Docker middleware framework. We introduce the concept of _configuration landscapes_ as bundles of configuration files that describe a certain environment. This is a first step to enabling users to easily switch between production, testing or teaching environments with a single command.
 
-As of now, there is only one landscape shipped with the image and we plan to add more over time depending on user needs. You can always create your own landscapes and quickly move between them. Check out the `docker-compose run eln landscape` command for more info.
+As of now, there is only one landscape shipped with the image and we plan to add more over time depending on user needs. You can always create your own landscapes and quickly move between them. Check out the `docker compose run eln landscape` command for more info.
 
 Further, this changed the config file structure a bit. While in previous versions, the ELN configuration was stored in `./shared/config` and the container configuration was stored in `./config`, there is only one folder now: `./shared`. We hope this change makes it more intuitive for users.
 
@@ -328,9 +328,9 @@ On the inside, we managed to reduce the size of our images by more than 50% by b
 
 
 ## Preparation
-To setup the Chemotion ELN using Docker, Docker and Docker-Compose have to be installed on the host machine. Please refer to your distributions documentation on how this can be achieved. For Ubuntu-based machines, this can be found [here](https://docs.docker.com/engine/install/ubuntu/).
+To setup the Chemotion ELN using Docker, Docker and Docker Compose have to be installed on the host machine. Please refer to your distributions documentation on how this can be achieved. For Ubuntu-based machines, this can be found [here](https://docs.docker.com/engine/install/ubuntu/).
 
-In addition you need that latest version of our Docker-Compose service description as well as some scripts depending on your scenario. The file can be found here:
+In addition you need that latest version of our Docker Compose service description as well as some scripts depending on your scenario. The file can be found here:
 
 | File | Description | 
 | ---- | ----------- |
@@ -368,19 +368,19 @@ You are now ready to run the initialization. Please note that this will create a
 
 ```
 cd $CHEMOTION_PATH
-docker-compose run eln landscape deploy
-docker-compose run eln init
+docker compose run eln landscape deploy
+docker compose run eln init
 ```
 
 As the previous command finishes, you are ready to start Chemotion:
 
 ```
-docker-compose up
+docker compose up
 ```
 
 You will see the system logs in your terminal and after the start-up you can access your fresh instance using a browser. The application is running on `http://localhost:4000`, the seeded administration account is `ADM` (all caps!) with password `PleaseChangeYourPassword`.
 
-To start your instance in background mode, use `docker-compose up -d`.
+To start your instance in background mode, use `docker compose up -d`.
 The services will automatically restart when the docker daemon restarts. This can be configured by removing the lines containing `restart: unless-stopped` in the `docker-compose.yml` file or disabling autostart of your docker daemon on your system:
 
 ```docker-compose.yml
@@ -404,7 +404,7 @@ Please refer to the Docker documentation on how this property works: https://doc
 To get basic information about your instance, run:
 
 ```
-docker-compose run eln info
+docker compose run eln info
 ```
 
 This will output storage, memory as well as several version information and ensure the fundamentally required runtime is correct.
@@ -414,7 +414,7 @@ This will output storage, memory as well as several version information and ensu
 To get access to the inside of the container, i.e to perform tasks based on the Rails console, one can use the following command:
 
 ```
-docker-compose run eln shell
+docker compose run eln shell
 ```
 
 This will drop you to a root shell inside the container. You are now free to perform any administrative tasks in the container context, but be aware that all changes are ephemeral and lost when the container is stopped. To access the host file system, a mount point has to be used, i.e. such as the already configured `/shared` (which - by default - maps to `./shared` on the host).
@@ -438,7 +438,7 @@ sudo bash ./backup.sh
  > Note: This upgrade is tailored and tested for the upgrade from 0.9.1 to 1.0.3.
  > Note: downgrading is not supported.
 
-Stop the services: `docker-compose stop --remove-orphans`
+Stop the services: `docker compose stop --remove-orphans`
 
 To upgrade your instance place the new `docker-compose.yml` and `upgrade.sh` in the directory where the Chemotion service files reside and run
 
@@ -450,11 +450,11 @@ This will make sure files are properly configured and the database schemes are a
 
  > Note: Without this step, the containers will refuse to start to prevent any possible damage to your installation.
 
-Now, restart the services: `docker-compose restart`
+Now, restart the services: `docker compose restart`
 
 ### Setting up a Reverse-Proxy
 
-To make the installation available to the public, the container's ports should to be forwarded. We suggest to run NGINX as a reverse-proxy either in docker (by extending the Docker-Compose service description file) or stand-alone on the host. The application is (by default) listening on '0.0.0.0:4000'.
+To make the installation available to the public, the container's ports should to be forwarded. We suggest to run NGINX as a reverse-proxy either in docker (by extending the Docker Compose service description file) or stand-alone on the host. The application is (by default) listening on '0.0.0.0:4000'.
 
 A demo service description as well as some sample configuration files for NGINX can be found in the Docker-Chemotion-Monorepo (https://github.com/ptrxyz/chemotion) in the sub-folder `reverse-proxy`.
 


### PR DESCRIPTION
Substitution of `docker-compose` with `docker compose`, as the first command is deprecated in current Docker versions. Also moved general Docker installation to the top and added a remark about rootless mode.