### PR TITLE
fix Last updated is not correct #278

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,11 @@ jobs:
   build_deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           cache: "npm"
 


### PR DESCRIPTION
Last update was missing because checkout did not have full git history (it was with `fetch-depth: 1`). Changed this to `fetch-depth: 0` to include full history.

Also updated actions/x to latest versions.