### PR TITLE
fix(UI): video display to fit available column width #355

### DIFF
--- a/docs/eln/ui/toolbar.mdx
+++ b/docs/eln/ui/toolbar.mdx
@@ -39,7 +39,6 @@ Possible search terms are **IUPAC** names, **InChI**, **SMILES**, **RInChI**. Th
 <YouTubeFrame
   src="https://www.youtube-nocookie.com/embed/4sAUs20QS0Q"
   title="Substructure search"
-  width="400"
 />
 <FigCaption text="Substructure search" />
 

--- a/docs/labimotion/guides/designer/components/fields/index.mdx
+++ b/docs/labimotion/guides/designer/components/fields/index.mdx
@@ -60,7 +60,6 @@ A terminology used to express the concept of this data field, providing a link t
 <YouTubeFrame
   src="https://www.youtube-nocookie.com/embed/P5OOXB0RyqU?list=PLZoVOhxCsajnl5_tveYUvtD0Y57devzdn"
   title="Designer - Linking an Ontology Term to a Field (HD)"
-  width="400"
 />
 <FigCaption text="Designer - Linking an Ontology Term to a Field" />
 

--- a/docs/labimotion/guides/designer/components/fields/types/formula-field.mdx
+++ b/docs/labimotion/guides/designer/components/fields/types/formula-field.mdx
@@ -38,7 +38,6 @@ Watch the video below to see how easy it is to use formula field.
 <YouTubeFrame
   src="https://www.youtube-nocookie.com/embed/KQiWymP4M-g"
   title="Designer - Formula Field"
-  width="400"
 />
 <FigCaption text="LabIMotion: Designer - Formula Field" />
 

--- a/docs/labimotion/guides/designer/components/fields/types/select.mdx
+++ b/docs/labimotion/guides/designer/components/fields/types/select.mdx
@@ -60,7 +60,6 @@ See the video below for a demonstration of how to set up a **Select** field.
 <YouTubeFrame
   src="https://www.youtube-nocookie.com/embed/Fgj0LqVrB6Q"
   title="LabIMotion - Add the Text field and Select field"
-  width="400"
 />
 <FigCaption text="Example: Designer - Add the Text field and Select field" />
 

--- a/docs/labimotion/guides/designer/components/fields/types/system-defined.mdx
+++ b/docs/labimotion/guides/designer/components/fields/types/system-defined.mdx
@@ -23,7 +23,6 @@ As a Designer, you can set a preferred unit for a field as the default option wi
 <YouTubeFrame
   src="https://www.youtube-nocookie.com/embed/mEmDDS9z19s"
   title="Designer - Customize Default Unit for Field"
-  width="400"
 />
 <FigCaption text="Customize Default Unit for System-Defined field (Temperature)" />
 

--- a/docs/labimotion/guides/designer/components/fields/types/table.mdx
+++ b/docs/labimotion/guides/designer/components/fields/types/table.mdx
@@ -42,7 +42,6 @@ A visual demonstration of the **Table** field is shown below:
 <YouTubeFrame
   src="https://www.youtube-nocookie.com/embed/4VfuIcR8X9k"
   title="LabIMotion - Table"
-  width="400"
 />
 <FigCaption text="Example: Designer - Add the Table field" />
 

--- a/docs/labimotion/guides/designer/components/layers/restriction-setting.mdx
+++ b/docs/labimotion/guides/designer/components/layers/restriction-setting.mdx
@@ -50,7 +50,6 @@ Quick catch up with the video below to see how to set up the restriction.
 <YouTubeFrame
   src="https://www.youtube-nocookie.com/embed/Ra6ro2F-ZLY"
   title="Designer: Layer Restriction Setting."
-  width="400"
 />
 
 <FigCaption text="Designer: Layer Restriction Setting." />

--- a/docs/labimotion/guides/designer/elements/copy.mdx
+++ b/docs/labimotion/guides/designer/elements/copy.mdx
@@ -19,6 +19,5 @@ The **Copy** function allows you to duplicate a selected element, creating an id
 <YouTubeFrame
   src="https://www.youtube-nocookie.com/embed/clgyLVICM5A"
   title="LabIMotion - Copy Element Template"
-  width="400"
 />
 <FigCaption text="LabIMotion: Designer - Copy Element Template" />

--- a/docs/labimotion/guides/designer/elements/index.mdx
+++ b/docs/labimotion/guides/designer/elements/index.mdx
@@ -41,7 +41,6 @@ Watch the video below to see how easy it is to perform sorting and filtering tas
 <YouTubeFrame
   src="https://www.youtube-nocookie.com/embed/tV4to8wc_e0"
   title="LabIMotion - Grid"
-  width="400"
 />
 <FigCaption text="Example: Generic Dataset Designer" />
 

--- a/docs/labimotion/guides/designer/elements/template.mdx
+++ b/docs/labimotion/guides/designer/elements/template.mdx
@@ -22,6 +22,5 @@ The **Template** function provides users with the capability to craft and person
 <YouTubeFrame
   src="https://www.youtube-nocookie.com/embed/nNAq63Cc1IQ"
   title="Sync Dataset from LabIMotion Hub"
-  width="400"
 />
 <FigCaption text="Designer - work area and preview of template" />

--- a/docs/labimotion/guides/designer/index.mdx
+++ b/docs/labimotion/guides/designer/index.mdx
@@ -42,7 +42,6 @@ Watch the video below to see how a designer can efficiently sync templates to yo
 <YouTubeFrame
   src="https://www.youtube-nocookie.com/embed/gddh2q5XYvQ"
   title="Sync Dataset from LabIMotion Hub"
-  width="400"
 />
 
 :::tip
@@ -60,7 +59,6 @@ Find templates that are suitable for your application in the **[LabIMotion Hub](
 <YouTubeFrame
   src="https://www.youtube-nocookie.com/embed/8o1U4QXU-B0"
   title="Designer, you design what you need."
-  width="400"
 />
 
 <FigCaption text="Designer, you design what you need." />

--- a/docs/labimotion/guides/designer/workflow/index.mdx
+++ b/docs/labimotion/guides/designer/workflow/index.mdx
@@ -23,7 +23,6 @@ The **Workflow** facilitates the seamless arrangement and organization of differ
 <YouTubeFrame
   src="https://www.youtube-nocookie.com/embed/k31WfTTTJ8I"
   title="Workflow design"
-  width="400"
 />
 
 :::info

--- a/docs/labimotion/guides/user/datasets/converter-metadata.mdx
+++ b/docs/labimotion/guides/user/datasets/converter-metadata.mdx
@@ -19,7 +19,6 @@ Combined with the power of the **[ChemConverter](/docs/services/chemconverter)**
 <YouTubeFrame
   src="https://www.youtube-nocookie.com/embed/OeY4ebfzfDg"
   title="Converter Metadata"
-  width="400"
 />
 
 <FigCaption text="LabIMotion + ChemConverter: automatically extract metadata from raw files and map it to the Generic Dataset." />

--- a/docs/labimotion/guides/user/elements/analysis-linkage.mdx
+++ b/docs/labimotion/guides/user/elements/analysis-linkage.mdx
@@ -19,5 +19,4 @@ The Analysis Linkage feature empowers users to seamlessly connect and integrate 
 <YouTubeFrame
   src="https://www.youtube-nocookie.com/embed/NVBiXoMZ3f0"
   title="Analysis Linkage"
-  width="400"
 />

--- a/docs/labimotion/guides/user/elements/copy-split.mdx
+++ b/docs/labimotion/guides/user/elements/copy-split.mdx
@@ -25,7 +25,6 @@ Quickly learn from the video:
 <YouTubeFrame
   src="https://www.youtube-nocookie.com/embed/rARGgJHN-xQ"
   title="Copy Element"
-  width="400"
 />
 <FigCaption text="Generic Element Copy Function" />
 
@@ -44,6 +43,5 @@ Watch a video demonstration:
 <YouTubeFrame
   src="https://www.youtube-nocookie.com/embed/pCFHtbhewhA"
   title="Generic Element Split Function"
-  width="400"
 />
 <FigCaption text="Generic Element Split Function" />

--- a/docs/labimotion/guides/user/elements/drag-element.mdx
+++ b/docs/labimotion/guides/user/elements/drag-element.mdx
@@ -20,5 +20,4 @@ Users can employ drag and drop functionality to add other elements to the conten
 <YouTubeFrame
   src="https://www.youtube-nocookie.com/embed/l0ZjILm8NZc"
   title="Analysis Linkage"
-  width="400"
 />

--- a/docs/labimotion/guides/user/elements/drag-sample.mdx
+++ b/docs/labimotion/guides/user/elements/drag-sample.mdx
@@ -30,7 +30,6 @@ When you drag a sample from the sample list to the element field, it becomes lin
 <YouTubeFrame
   src="https://www.youtube-nocookie.com/embed/4xfPtWg7S-I"
   title="Converter Metadata."
-  width="400"
 />
 
 ## Drag samples to table

--- a/docs/labimotion/guides/user/elements/report.mdx
+++ b/docs/labimotion/guides/user/elements/report.mdx
@@ -19,6 +19,5 @@ The Generic Elements **Report Generation** feature is very helpful for scientist
 <YouTubeFrame
   src="https://www.youtube-nocookie.com/embed/XUbMF99Aku0"
   title="Generic Element Report Generation"
-  width="400"
 />
 <FigCaption text="Generic Element Report Generation" />

--- a/docs/labimotion/guides/user/features/repetition-layers.mdx
+++ b/docs/labimotion/guides/user/features/repetition-layers.mdx
@@ -25,5 +25,4 @@ The **Repetition of Layers** function empowers users to duplicate generic elemen
 <YouTubeFrame
   src="https://www.youtube-nocookie.com/embed/aYgw3Mo-ymI"
   title="Repetition of layers."
-  width="400"
 />

--- a/docs/labimotion/guides/user/segments/copy.mdx
+++ b/docs/labimotion/guides/user/segments/copy.mdx
@@ -19,7 +19,6 @@ When you duplicate an existing element, all its segments will be duplicated as w
 <YouTubeFrame
   src="https://www.youtube-nocookie.com/embed/CbWcZp-cP6Y"
   title="Copy Segment"
-  width="400"
 />
 
 :::warning

--- a/docs/labimotion/guides/user/segments/index.mdx
+++ b/docs/labimotion/guides/user/segments/index.mdx
@@ -34,7 +34,6 @@ However, if segments are created, they will be visible even if they are in the h
 <YouTubeFrame
   src="https://www.youtube-nocookie.com/embed/xgoX_3BK4rg"
   title="Designer, you design what you need."
-  width="400"
 />
 <FigCaption text="LabIMotion - Embedded a segment into sample." />
 
@@ -43,7 +42,6 @@ Depending on the design, the segments can be used for basic elements, such as sa
 <YouTubeFrame
   src="https://www.youtube-nocookie.com/embed/ubCwjvIEjug"
   title="User - Embedded segment in element."
-  width="400"
 />
 <FigCaption text="LabIMotion - Embedded a segment into generic element." />
 

--- a/docs/labimotion/template-sync-and-publish.mdx
+++ b/docs/labimotion/template-sync-and-publish.mdx
@@ -35,7 +35,6 @@ Watch our video to see how a designer can sync the template back to your own ins
 <YouTubeFrame
   src="https://www.youtube-nocookie.com/embed/gddh2q5XYvQ"
   title="Sync Dataset from LabIMotion Hub"
-  width="400"
 />
 
 ## Publish your work
@@ -61,7 +60,7 @@ Template fetching is performed by the Designer.
 <YouTubeFrame
   src="https://www.youtube-nocookie.com/embed/6X-JYOXG1wQ"
   title="MOF publication"
-  width="400"
+  width="100%"
 />
 
 ### Learn more about

--- a/docs/repo/viewer.mdx
+++ b/docs/repo/viewer.mdx
@@ -13,5 +13,4 @@ The function supports viewing various file formats, including CIF, MOL, SDF, PDB
 <YouTubeFrame
   src="https://www.youtube-nocookie.com/embed/ZXdsjsznok0"
   title="3D Viewer"
-  width="400"
 />

--- a/docs/repo/workflow/new.mdx
+++ b/docs/repo/workflow/new.mdx
@@ -80,5 +80,4 @@ Please refer to the visualized video below:
 <YouTubeFrame
   src="https://www.youtube-nocookie.com/embed/PMeDUJlISVI"
   title="Sync Dataset from LabIMotion Hub"
-  width="400"
 />

--- a/src/js/gallery.js
+++ b/src/js/gallery.js
@@ -5,20 +5,15 @@ import { YouTubeFrame } from "@site/src/js/layout";
 export function Gallery({ links, titles }) {
   return (
     <div>
-      <div className="row">
-        {links.map((link, idx) => (
-          <div className="col margin-top--lg margin-bottom--lg">
-            {/* <ReactMarkdown source={'## '+ titles[idx]} /> */}
-            <h3>{titles[idx]}</h3>
-            <YouTubeFrame
-              width="400"
-              height="225"
-              src={link}
-              title={titles[idx]}
-            />
-          </div>
-        ))}
-      </div>
+      {links.map((link, idx) => (
+        <div>
+          <h3>{titles[idx]}</h3>
+          <YouTubeFrame
+            src={link}
+            title={titles[idx]}
+          />
+        </div>
+      ))}
     </div>
   );
 }

--- a/src/js/layout.js
+++ b/src/js/layout.js
@@ -10,9 +10,11 @@ function imageUrlForYouTube(url) {
 
 export const SubTitle = ({ text }) => (<h3 className="subTitle">{text}</h3>);
 export const FigCaption = ({ text }) => (<h3 className="figCaption">{text}</h3>);
-export const YouTubeFrame = ({ src, title, width, height }) =>
-(<VideoPrivacy customButtonClass="button button--primary" info="YouTube will track your interaction with them." width={width + "px"} imageUrl={imageUrlForYouTube(src)}>
-    <iframe src={src} title={title} width={width} height={height} allowFullScreen
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" />
-</VideoPrivacy>);
+export const YouTubeFrame = ({ src, title }) =>
+(<div style={{ position: "relative", aspectRatio: 1.7778 }}>
+    <VideoPrivacy customButtonClass="button button--primary" info="YouTube will track your interaction with them." width="100%" imageUrl={imageUrlForYouTube(src)}>
+        <iframe src={src} title={title} position="relative" width="100%" height="100%"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" />
+    </VideoPrivacy >
+</div>);
 export const Reader = ({ text }) => (<span className="theme-doc-version-badge badge badge--secondary reader-badge">Reader: {text}</span>);

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -5,7 +5,7 @@ import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import styles from './styles.module.css';
-import { YouTubeFrame } from "@site/src/js/layout";
+import VideoPrivacy from "video-privacy"
 
 const features = [
   {
@@ -83,12 +83,16 @@ function Home() {
           </div>
           <div className="column">
             <div style={{ margin: '2rem auto 0 auto', textAlign: 'center' }}>
-              <YouTubeFrame
-                width="640"
-                height="360"
-                src="https://www.youtube-nocookie.com/embed/tZHaP6DW-Dw"
-                title="Chemotion ELN and repository"
-              />
+              <VideoPrivacy customButtonClass="button button--primary" info="YouTube will track your interaction with them." width="640px" imageUrl="/img/yt_thumbnails/tZHaP6DW-Dw.jpg">
+                <iframe
+                  width="640"
+                  height="360"
+                  src="https://www.youtube-nocookie.com/embed/tZHaP6DW-Dw"
+                  title="YouTube video player"
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                  allowFullScreen
+                />
+              </VideoPrivacy>
             </div>
           </div>
         </div>


### PR DESCRIPTION
- needs further refinement:
  - columns need to be restored in the gallery component
  - all videos currently sized at 100% of their container and at 16:9 ratio
  - ideally these should be customizable