### PR TITLE
docs: remove obsolete scifinder troubleshooting advice

### DIFF
--- a/docs/eln/troubleshooting.mdx
+++ b/docs/eln/troubleshooting.mdx
@@ -15,12 +15,6 @@ Check whether you are in your work collection. The **All Collection** tab is not
 
 If you want to carry out an action and the corresponding button for carrying it out is not activated, it may be because you first have to save your previous entries. This error occurs, for example, if you want to edit a sample in a reaction, but the sample has recently been inserted into the reaction table (by **split** or **copy**). If the new sample has not yet been saved in the reaction table, you cannot use various functions.
 
-## SciFinder error 500
-
-A possible error message that can appear when using the SciFinder function to search for samples or reactions is the error code Error 500.
-![SciFinder error 500](/img/scifinder_error_500.png)
-This error occurs when the SciFinder access has not been released and therefore access to the database is denied. Please check whether your SciFinder token is still valid by checking the date in the action bar under **Log in as your name** and **Settings**. If the validity date has been exceeded, you can easily renew it by deleting the token and creating a new one by entering your SciFinder access data. The new token is then valid again for one week.
-
 ## Fixing Sample or Molecule SVG images
 
 **(in ELN v1.5.4 and above)**


### PR DESCRIPTION
(obsolete for ELN version >= v1.2)