### PR TITLE
Update reactions.mdx

### DIFF
--- a/docs/eln/ui/elements/reactions.mdx
+++ b/docs/eln/ui/elements/reactions.mdx
@@ -42,14 +42,6 @@ and you can make the selection directly.
 Once a reaction is generated, its details panel is displayed, and the user can fill the reaction with the interacting samples and the resulting products from within the **Scheme** tab.
 More details about populating a reaction with samples can be found in the [Details panel for reactions](../details#details-panel-for-reactions) chapter.
 
-:::danger[Caution]
-
-To balance your equation, changing coefficients is still not possible,
-so you need multiple samples to express a single molecule when it has a coefficient more than one.
-This step is important for correct calculations of the yield.
-
-:::
-
 ## Reactions in the element bar
 
 <img


### PR DESCRIPTION
The "caution" box in chapter "Generation" states that coefficients do not work in the reaction element, which is outdated. Therefore, I removed the warning.