### PR TITLE
fix: Change 'Versions' tab to 'History' tab in documentation

### DIFF
--- a/docs/eln/ui/history.mdx
+++ b/docs/eln/ui/history.mdx
@@ -9,8 +9,8 @@ This feature will be available from v2.0.
 samples, reactions, wellplates (including wells), research plans, screens
 :::
 
-## Versions Tab
-This feature can be found in each element under the "Versions" tab.
+## History Tab
+This feature can be found in each element under the "History" tab.
 If you can't see the tab, look [here](./view#adjust-the-tabs-in-detail-modal)
 how to display hidden tabs.
 In this tab you can see a version for each change: ![versions](/img/history/versions.png)


### PR DESCRIPTION
Updated the documentation to reflect the correct tab name for version tracking.