### PR TITLE
docs: add pages for new `element` kinds

### DIFF
--- a/docs/eln/ui/elements/device_description.mdx
+++ b/docs/eln/ui/elements/device_description.mdx
@@ -1,0 +1,4 @@
+---
+title: Device Description
+sidebar_position: 6
+---

--- a/docs/eln/ui/elements/grouping.mdx
+++ b/docs/eln/ui/elements/grouping.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Grouping Elements Together"
+title: Grouping Elements Together
 sidebar_label: Grouping Elements
 sidebar_position: 9
 ---

--- a/docs/eln/ui/elements/macromolecules.mdx
+++ b/docs/eln/ui/elements/macromolecules.mdx
@@ -1,0 +1,4 @@
+---
+title: Sequence-Based Macromolecules
+sidebar_position: 5
+---


### PR DESCRIPTION
Place holders for `Sequence-Based Macromolecules` and `Device Description` element kinds.