### PR TITLE
ci: build and deploy the docs site from a gated production environment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,10 +3,14 @@ name: Build (CI)
 # Deploys are handled by deploy.yml on push to main. This workflow is the
 # build-only check for everything else — it proves the site still compiles and
 # that onBrokenLinks: "throw" is satisfied before a change reaches main.
+#
+# pull_request only, deliberately. Adding `push` as well ran this twice on every
+# SHA in a PR branch — once per event — and a concurrency group cannot dedupe
+# them, because github.ref differs between the two (refs/heads/… vs
+# refs/pull/N/merge). workflow_dispatch covers the gap for a branch with no PR yet.
 on:
   pull_request:
-  push:
-    branches-ignore: [main]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,17 +1,27 @@
-name: chemotion_saurus GitHub Actions
+name: Build (CI)
 
+# Deploys are handled by deploy.yml on push to main. This workflow is the
+# build-only check for everything else — it proves the site still compiles and
+# that onBrokenLinks: "throw" is satisfied before a change reaches main.
 on:
+  pull_request:
   push:
+    branches-ignore: [main]
 
 jobs:
-  build_deploy:
+  build:
+    name: Build
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v5
+      - name: Check out
+        uses: actions/checkout@v6
         with:
+          # docusaurus.config.js sets showLastUpdateTime, which reads git history.
           fetch-depth: 0
 
-      - uses: actions/setup-node@v6
+      - name: Setup Node
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: "npm"
@@ -24,29 +34,10 @@ jobs:
             fi
           done
 
+      - name: Install deps
+        run: npm ci
+
       - name: Build
-        id: build
         env:
           DOCUSAURUS_IGNORE_SSG_WARNINGS: true
-        run: |
-          npm install -g npm
-          npm install
-          npm run build
-
-      - name: Deploy
-        if: steps.build.outcome == 'success' && github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'skip deploy')
-        env:
-          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-        run: |
-          #!/usr/bin/env bash
-          set -euo pipefail
-          eval $(ssh-agent -s);
-          mkdir ~/.ssh/
-          chmod 700 ~/.ssh
-          echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
-          ssh-add ~/.ssh/id_rsa
-          touch ~/.ssh/known_hosts
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
-          chmod 600 ~/.ssh/known_hosts
-          rsync -e "ssh -o StrictHostKeyChecking=no" -az --delete ./build/ saurus@chemotion.net:docs/chemotion_saurus/.
+        run: npm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,119 @@
+name: Build & Deploy (docs site)
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: "deploy-production"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@v6
+        with:
+          # docusaurus.config.js sets showLastUpdateTime, which reads git history.
+          # A shallow clone silently degrades every page's "Last updated" date.
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: "npm"
+
+      - name: Download YT Thumbnails
+        run: |
+          for file in $(grep -hroP 'youtube-nocookie.com/embed/.{11}' docs | cut -d / -f 3); do
+            if [ ! -f "static/img/yt_thumbnails/$file.jpg" ]; then
+              wget -O "static/img/yt_thumbnails/$file.jpg" "https://img.youtube.com/vi/$file/hqdefault.jpg" || wget -O "static/img/yt_thumbnails/$file.jpg" "https://img.youtube.com/vi/$file/0.jpg"
+            fi
+          done
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Build
+        env:
+          DOCUSAURUS_IGNORE_SSG_WARNINGS: true
+        run: npm run build
+
+      - name: Prepare artifact
+        run: |
+          test -f build/index.html || { echo "build/ is missing or empty — aborting"; exit 1; }
+          tar -czf site-artifact.tgz -C build .
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: site-out
+          path: site-artifact.tgz
+          retention-days: 1
+          if-no-files-found: error
+          # The payload is ~1 GB, already gzipped and mostly GIFs — re-zipping it
+          # on upload costs minutes of CPU and saves nothing.
+          compression-level: 0
+
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: site-out
+          path: artifact
+
+      - name: Unpack artifact
+        run: |
+          mkdir -p site-out
+          tar -xzf artifact/site-artifact.tgz -C site-out
+          test -f site-out/index.html || { echo "unpacked artifact has no index.html — aborting"; exit 1; }
+
+      - name: Setup SSH
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: Verify host fingerprint
+        env:
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          SSH_PORT: ${{ secrets.SSH_PORT }}
+          SSH_HOST_FINGERPRINT: ${{ secrets.SSH_HOST_FINGERPRINT }}
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          PORT=${SSH_PORT:-22}
+          ssh-keyscan -p "$PORT" -H "$SSH_HOST" >> ~/.ssh/known_hosts
+          ssh-keygen -l -f ~/.ssh/known_hosts | grep -qF "$SSH_HOST_FINGERPRINT" \
+            || { echo "Host fingerprint mismatch — aborting"; exit 1; }
+
+      - name: Push artifact to remote
+        env:
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_PORT: ${{ secrets.SSH_PORT }}
+        run: |
+          PORT=${SSH_PORT:-22}
+          SSH_OPTS="-p $PORT -o StrictHostKeyChecking=yes"
+
+          # The deploy account's home is the docroot. --delete prunes stale pages, but
+          # would also remove login files if the account is ever un-jailed, so guard
+          # the usual dotfiles explicitly.
+          rsync -az --delete \
+            --exclude='.ssh/' \
+            --exclude='.cache/' \
+            --exclude='.bashrc' \
+            --exclude='.bash_logout' \
+            --exclude='.bash_history' \
+            --exclude='.profile' \
+            -e "ssh $SSH_OPTS" \
+            site-out/ "$SSH_USER@$SSH_HOST:."

--- a/README.md
+++ b/README.md
@@ -48,9 +48,17 @@ npm run serve
 
 ## Deployment
 
-![code status](https://github.com/ComPlat/chemotion_saurus/actions/workflows/build.yml/badge.svg)
+[![deploy status](https://github.com/ComPlat/chemotion_saurus/actions/workflows/deploy.yml/badge.svg)](https://github.com/ComPlat/chemotion_saurus/actions/workflows/deploy.yml)
+[![build status](https://github.com/ComPlat/chemotion_saurus/actions/workflows/build.yml/badge.svg)](https://github.com/ComPlat/chemotion_saurus/actions/workflows/build.yml)
 
-The website is deployed with GitHub Actions [here](https://github.com/ComPlat/chemotion_saurus/blob/aa6fe5cc1ade8517f855a7df1ef4f6d648c67f26/.github/workflows/build.yml#L40).
+Every push to `main` runs [`.github/workflows/deploy.yml`](.github/workflows/deploy.yml): the
+site is built, uploaded as an artifact, and rsynced to the hosting account from a `deploy` job
+gated on the `production` GitHub environment. Pull requests and other branches run
+[`.github/workflows/build.yml`](.github/workflows/build.yml), which builds only.
+
+The SSH credentials (`SSH_PRIVATE_KEY`, `SSH_HOST`, `SSH_USER`, `SSH_PORT`,
+`SSH_HOST_FINGERPRINT`) are stored as **environment** secrets on `production`, and the deploy
+aborts unless the remote host key matches `SSH_HOST_FINGERPRINT`.
 
 ## Acknowledgments
 


### PR DESCRIPTION
Rebuilds the docs-site autodeploy to match the pattern established for the smartadd service in ComPlat/smart-add#63, now that chemotion.net hosting is set up the same way.

**Draft** because it must not merge until the GitHub repo settings below exist — merging first produces a failed deploy on the very next push to `main`.

## What changes

| File | Trigger | Does |
|---|---|---|
| `.github/workflows/deploy.yml` *(new)* | push to `main` | build → upload artifact → deploy via the `production` environment |
| `.github/workflows/build.yml` | `pull_request`, `workflow_dispatch` | build only, no credentials in scope |

### Security

- **Deploy job runs in a gated `production` environment.** The SSH key is no longer in scope while `npm ci` executes third-party dependency code — that separation is the main reason for the two-job split.
- **`ssh-agent` instead of writing the key to disk.** The old job wrote `$SSH_PRIVATE_KEY` to `~/.ssh/id_rsa` on the runner.
- **Host key pinning.** The old job ran `ssh-keyscan github.com` and then passed `-o StrictHostKeyChecking=no` to the deploy — so the deploy host's identity was never verified at all. It is now scanned and matched against `SSH_HOST_FINGERPRINT`, aborting on mismatch.
- **Host, user and port come from environment secrets** rather than being hardcoded to `saurus@chemotion.net`.

### Safety

- The build job asserts `build/index.html` exists before tarring, and the deploy job asserts it survives unpacking. An empty build therefore cannot reach `rsync --delete`. This is not hypothetical: the WIP workflow this replaces retained the Next.js `mkdir -p artifact/standalone && tar …` scaffolding with the copy steps removed, so it tarred an empty directory — a 1-entry tarball, verified — and would have wiped the live site on the first run.
- The rsync target is the deploy account's home directory, so `--delete` is given explicit `--exclude` guards for `.ssh/`, `.bashrc` and friends. Dry-run against a simulated home-dir docroot deletes only stale content and leaves `authorized_keys` intact.

### Build correctness

- `fetch-depth: 0` is kept deliberately — `docusaurus.config.js` sets `showLastUpdateTime`, which reads git history; a shallow clone silently blanks every page's "Last updated" date.
- `npm ci` replaces `npm install -g npm && npm install`, matching what `railpack-plan.json` already does.
- `compression-level: 0` on the artifact upload: the payload is already gzipped and mostly GIFs, so re-zipping costs CPU for nothing. (The ~1 GB build size is pre-existing and tracked separately.)
- `build.yml` triggers on `pull_request` only. An earlier revision of this branch also had a `push` trigger, which built every SHA twice — once per event. A `concurrency` group cannot dedupe those, because `github.ref` differs between them (`refs/heads/…` vs `refs/pull/N/merge`), so the `push` trigger was dropped instead. `main` is covered by `deploy.yml`, and `workflow_dispatch` covers a branch with no PR yet.

## Required before merge

The `production` environment does not exist yet. A maintainer needs to:

1. Create the **`production`** environment.
2. Add five **environment** secrets: `SSH_PRIVATE_KEY`, `SSH_HOST`, `SSH_USER`, `SSH_PORT`, `SSH_HOST_FINGERPRINT`. Obtain the last with `ssh-keyscan -p <port> -H <host> | ssh-keygen -lf -` and store just the `SHA256:…` token — the workflow matches it as a literal substring.
3. Restrict its deployment branches to **`main`** only.
4. Move the existing repo-level `SSH_PRIVATE_KEY` into the environment and delete the repo-level copy.
5. Allow-list `webfactory/ssh-agent` if the org restricts actions to verified creators, or the deploy fails at Setup SSH.

Also needs confirming server-side, and this one is blocking: that the deploy account is jailed to the docroot, and that the docroot really is its home directory rather than the old `docs/chemotion_saurus/` subpath. `baseUrl` is `/docs`, so if the new hosting still serves from a subdirectory the rsync target needs that path instead and the site 404s until it is changed.

## Verification so far

- Both workflows parse as valid YAML (`actionlint` was not available locally).
- `npm ci` + build reproduced locally; the artifact is 1864 entries and contains `index.html` — versus the 1-entry tarball the replaced WIP produced.
- `rsync --delete --dry-run` against a simulated home-directory docroot removes only stale content and preserves `.ssh/authorized_keys`.
- `ssh-keyscan … | ssh-keygen -lf -` confirmed to yield usable `SHA256:` fingerprints for the target host.
- The build job passes on CI, and the trigger fix is confirmed: one run on the current head against two on the previous one.

The **deploy** job is not yet exercised end-to-end — that needs the environment to exist, which is why this is a draft.
